### PR TITLE
Allow testing XCM

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -103,7 +103,13 @@ RUN cargo +nightly install cargo-dylint dylint-link && \
     # install `polkadot-sdk`
     git clone --depth 1 --branch ${POLKADOT_SDK_BRANCH} https://github.com/paritytech/polkadot-sdk.git && \
     cd polkadot-sdk/ && \
-    cargo +nightly install --path substrate/bin/utils/subkey --locked && \
+    cargo install --path substrate/bin/utils/subkey --locked && \
+    cd polkadot && cargo install --bin polkadot --locked && cd .. && \
+    cargo install --path substrate/bin/utils/chain-spec-builder/Cargo.toml && \
+    cargo install --path cumulus/polkadot-parachain/Cargo.toml && \
+    cargo build --release --manifest-path cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml && \
+    export runtime=target/release/wbuild/asset-hub-westend-runtime/asset_hub_westend_runtime.wasm && \
+    chain-spec-builder -c "/dev/stdout" create --relay-chain "dev" --para-id 1000 -r $runtime named-preset development > ../westend.json && \
     # cargo +nightly install --path substrate/frame/revive/rpc --locked && \
     cd ../ && rm -rf polkadot-sdk/ && \
     # We require `grcov` for coverage reporting and `rust-covfix` to improve it.


### PR DESCRIPTION
The parachain setup of our `ink-node` (`--chain ink-parachain-local`) is currently broken (blocks are not being build). Until we've fixed it, I'm installing everything needed to test XCM in the Docker image.

The command to run the relaychain + parachain is then:
```
$ polkadot-parachain --chain westend.json --dev -lerror,runtime::revive=trace
```

I've opted for Westend Asset Hub, as it's the only runtime in `polkadot-sdk` that has the `XcmPrecompile` enabled.